### PR TITLE
Fix route tracing to start from user's real location

### DIFF
--- a/client/components/shared/RouteConfigurationModal.tsx
+++ b/client/components/shared/RouteConfigurationModal.tsx
@@ -264,7 +264,9 @@ const RouteConfigurationModal: React.FC<RouteConfigurationModalProps> = ({
 
         // Se estiver no modo de traçamento e tiver paradas suficientes, finalizar planejamento
         if (traceContext.state.isTracing && formData.stops.length >= 1) {
-          console.log("Configurações salvas, finalizando planejamento automaticamente...");
+          console.log(
+            "Configurações salvas, finalizando planejamento automaticamente...",
+          );
           // Fechar modal primeiro
           setIsSuccess(true);
           setIsLoading(false);
@@ -273,7 +275,9 @@ const RouteConfigurationModal: React.FC<RouteConfigurationModalProps> = ({
             setIsSuccess(false);
             onClose();
             // Finalizar planejamento automaticamente após salvar
-            console.log("Chamando showTraceConfirmation() para finalizar planejamento");
+            console.log(
+              "Chamando showTraceConfirmation() para finalizar planejamento",
+            );
             traceContext.showTraceConfirmation();
           }, 1500);
 
@@ -376,10 +380,12 @@ const RouteConfigurationModal: React.FC<RouteConfigurationModalProps> = ({
         <div className="pt-4 border-t border-border">
           <Button
             onClick={handleFinalSubmit}
-            disabled={isLoading ||
+            disabled={
+              isLoading ||
               (isInMapPage && traceContext.state.isTracing
                 ? formData.stops.length < 1
-                : !isFormValid())}
+                : !isFormValid())
+            }
             className="w-full"
           >
             {isLoading ? (
@@ -392,7 +398,9 @@ const RouteConfigurationModal: React.FC<RouteConfigurationModalProps> = ({
             ) : (
               <>
                 <Save className="h-4 w-4 mr-2" />
-                {isInMapPage && traceContext.state.isTracing && formData.stops.length >= 1
+                {isInMapPage &&
+                traceContext.state.isTracing &&
+                formData.stops.length >= 1
                   ? "Finalizar Planejamento"
                   : isInMapPage
                     ? "Salvar Configurações"

--- a/client/components/shared/RouteConfigurationModal.tsx
+++ b/client/components/shared/RouteConfigurationModal.tsx
@@ -381,7 +381,11 @@ const RouteConfigurationModal: React.FC<RouteConfigurationModalProps> = ({
             ) : (
               <>
                 <Save className="h-4 w-4 mr-2" />
-                {isInMapPage ? "Salvar Configurações" : "Preparar Rota"}
+                {isInMapPage && traceContext.state.isTracing && formData.stops.length >= 2
+                  ? "Finalizar Planejamento"
+                  : isInMapPage
+                    ? "Salvar Configurações"
+                    : "Preparar Rota"}
               </>
             )}
           </Button>

--- a/client/components/shared/RouteConfigurationModal.tsx
+++ b/client/components/shared/RouteConfigurationModal.tsx
@@ -171,7 +171,7 @@ const RouteConfigurationModal: React.FC<RouteConfigurationModalProps> = ({
     },
     {
       id: "scheduling",
-      title: "Programação",
+      title: "Programa��ão",
       subtitle: "Tipo e data.",
       icon: Calendar,
       component: SchedulingPage,
@@ -241,7 +241,13 @@ const RouteConfigurationModal: React.FC<RouteConfigurationModalProps> = ({
 
   // Envio final com comportamento baseado no contexto
   const handleFinalSubmit = async () => {
-    if (!isFormValid()) {
+    // Na página do mapa, validar apenas se tem paradas para finalizar o planejamento
+    if (isInMapPage && traceContext.state.isTracing) {
+      if (formData.stops.length < 2) {
+        alert("Adicione pelo menos 2 paradas para finalizar o planejamento.");
+        return;
+      }
+    } else if (!isFormValid()) {
       alert(
         "Por favor, preencha os campos obrigatórios: Informações da Rota, Paradas e Programação.",
       );

--- a/client/components/shared/RouteConfigurationModal.tsx
+++ b/client/components/shared/RouteConfigurationModal.tsx
@@ -378,7 +378,7 @@ const RouteConfigurationModal: React.FC<RouteConfigurationModalProps> = ({
             onClick={handleFinalSubmit}
             disabled={isLoading ||
               (isInMapPage && traceContext.state.isTracing
-                ? formData.stops.length < 2
+                ? formData.stops.length < 1
                 : !isFormValid())}
             className="w-full"
           >

--- a/client/components/shared/RouteConfigurationModal.tsx
+++ b/client/components/shared/RouteConfigurationModal.tsx
@@ -252,13 +252,24 @@ const RouteConfigurationModal: React.FC<RouteConfigurationModalProps> = ({
 
     try {
       if (isInMapPage) {
-        // Na página do mapa: manter funções existentes
+        // Na página do mapa: salvar configurações e finalizar planejamento
         await new Promise((resolve) => setTimeout(resolve, 1500));
         console.log("Dados da rota salvos (página mapa):", formData);
 
-        // Sincronizar as paradas com o contexto se necessário
-        if (traceContext.state.isTracing && formData.stops.length > 0) {
-          // Lógica específica para o mapa pode ser adicionada aqui
+        // Se estiver no modo de traçamento e tiver paradas suficientes, finalizar planejamento
+        if (traceContext.state.isTracing && formData.stops.length >= 2) {
+          // Fechar modal primeiro
+          setIsSuccess(true);
+          setIsLoading(false);
+
+          setTimeout(() => {
+            setIsSuccess(false);
+            onClose();
+            // Finalizar planejamento automaticamente após salvar
+            traceContext.showTraceConfirmation();
+          }, 1500);
+
+          return; // Sair early para não executar o resto da função
         }
       } else {
         // Fora da página do mapa: não fazer nada por enquanto

--- a/client/components/shared/RouteConfigurationModal.tsx
+++ b/client/components/shared/RouteConfigurationModal.tsx
@@ -171,7 +171,7 @@ const RouteConfigurationModal: React.FC<RouteConfigurationModalProps> = ({
     },
     {
       id: "scheduling",
-      title: "Programa��ão",
+      title: "Programação",
       subtitle: "Tipo e data.",
       icon: Calendar,
       component: SchedulingPage,
@@ -374,7 +374,10 @@ const RouteConfigurationModal: React.FC<RouteConfigurationModalProps> = ({
         <div className="pt-4 border-t border-border">
           <Button
             onClick={handleFinalSubmit}
-            disabled={isLoading || !isFormValid()}
+            disabled={isLoading ||
+              (isInMapPage && traceContext.state.isTracing
+                ? formData.stops.length < 2
+                : !isFormValid())}
             className="w-full"
           >
             {isLoading ? (

--- a/client/components/shared/RouteConfigurationModal.tsx
+++ b/client/components/shared/RouteConfigurationModal.tsx
@@ -392,7 +392,7 @@ const RouteConfigurationModal: React.FC<RouteConfigurationModalProps> = ({
             ) : (
               <>
                 <Save className="h-4 w-4 mr-2" />
-                {isInMapPage && traceContext.state.isTracing && formData.stops.length >= 2
+                {isInMapPage && traceContext.state.isTracing && formData.stops.length >= 1
                   ? "Finalizar Planejamento"
                   : isInMapPage
                     ? "Salvar Configurações"

--- a/client/components/shared/RouteConfigurationModal.tsx
+++ b/client/components/shared/RouteConfigurationModal.tsx
@@ -243,8 +243,8 @@ const RouteConfigurationModal: React.FC<RouteConfigurationModalProps> = ({
   const handleFinalSubmit = async () => {
     // Na página do mapa, validar apenas se tem paradas para finalizar o planejamento
     if (isInMapPage && traceContext.state.isTracing) {
-      if (formData.stops.length < 2) {
-        alert("Adicione pelo menos 2 paradas para finalizar o planejamento.");
+      if (formData.stops.length < 1) {
+        alert("Adicione pelo menos 1 parada para finalizar o planejamento.");
         return;
       }
     } else if (!isFormValid()) {

--- a/client/components/shared/RouteConfigurationModal.tsx
+++ b/client/components/shared/RouteConfigurationModal.tsx
@@ -263,7 +263,7 @@ const RouteConfigurationModal: React.FC<RouteConfigurationModalProps> = ({
         console.log("Dados da rota salvos (página mapa):", formData);
 
         // Se estiver no modo de traçamento e tiver paradas suficientes, finalizar planejamento
-        if (traceContext.state.isTracing && formData.stops.length >= 2) {
+        if (traceContext.state.isTracing && formData.stops.length >= 1) {
           console.log("Configurações salvas, finalizando planejamento automaticamente...");
           // Fechar modal primeiro
           setIsSuccess(true);

--- a/client/components/shared/RouteConfigurationModal.tsx
+++ b/client/components/shared/RouteConfigurationModal.tsx
@@ -264,6 +264,7 @@ const RouteConfigurationModal: React.FC<RouteConfigurationModalProps> = ({
 
         // Se estiver no modo de traçamento e tiver paradas suficientes, finalizar planejamento
         if (traceContext.state.isTracing && formData.stops.length >= 2) {
+          console.log("Configurações salvas, finalizando planejamento automaticamente...");
           // Fechar modal primeiro
           setIsSuccess(true);
           setIsLoading(false);
@@ -272,6 +273,7 @@ const RouteConfigurationModal: React.FC<RouteConfigurationModalProps> = ({
             setIsSuccess(false);
             onClose();
             // Finalizar planejamento automaticamente após salvar
+            console.log("Chamando showTraceConfirmation() para finalizar planejamento");
             traceContext.showTraceConfirmation();
           }, 1500);
 

--- a/client/components/shared/ViweRouteTracer.tsx
+++ b/client/components/shared/ViweRouteTracer.tsx
@@ -1,0 +1,49 @@
+import React from "react";
+import { ViweLoaderInline } from "./ViweLoader";
+import { Route, Zap, MapPin } from "lucide-react";
+
+interface ViweRouteTracerProps {
+  isVisible: boolean;
+  stopsCount: number;
+  isTracing: boolean;
+}
+
+/**
+ * Componente que mostra feedback visual durante o traçamento de rota
+ * Aparece na parte superior da tela quando a rota está sendo traçada
+ */
+const ViweRouteTracer: React.FC<ViweRouteTracerProps> = ({
+  isVisible,
+  stopsCount,
+  isTracing,
+}) => {
+  if (!isVisible) return null;
+
+  return (
+    <div className="fixed top-4 left-4 right-4 z-50 bg-blue-600 text-white rounded-xl p-3 shadow-lg mx-auto max-w-sm">
+      <div className="flex items-center space-x-3">
+        <div className="flex-shrink-0">
+          {isTracing ? (
+            <ViweLoaderInline size="sm" className="text-white" />
+          ) : (
+            <Zap className="h-5 w-5 text-yellow-300" />
+          )}
+        </div>
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center space-x-2">
+            <Route className="h-4 w-4" />
+            <span className="font-medium text-sm">
+              {isTracing ? "Traçando rota..." : "Rota traçada!"}
+            </span>
+          </div>
+          <div className="flex items-center space-x-1 text-xs text-blue-100">
+            <MapPin className="h-3 w-3" />
+            <span>{stopsCount} paradas conectadas</span>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ViweRouteTracer;

--- a/client/components/shared/ViweRouteTracer.tsx
+++ b/client/components/shared/ViweRouteTracer.tsx
@@ -38,7 +38,11 @@ const ViweRouteTracer: React.FC<ViweRouteTracerProps> = ({
           </div>
           <div className="flex items-center space-x-1 text-xs text-blue-100">
             <MapPin className="h-3 w-3" />
-            <span>{stopsCount} paradas conectadas</span>
+            <span>
+              {isTracing
+                ? `Da sua localização → ${stopsCount} paradas`
+                : `Localização atual → ${stopsCount} paradas conectadas`}
+            </span>
           </div>
         </div>
       </div>

--- a/client/contexts/TraceRouteContext.tsx
+++ b/client/contexts/TraceRouteContext.tsx
@@ -256,11 +256,19 @@ export const TraceRouteProvider: React.FC<TraceRouteProviderProps> = ({
       order: state.stops.length + 1,
     };
 
-    setState((prev) => ({
-      ...prev,
-      stops: [...prev.stops, newStop],
-      estimatedCredits: Math.min(prev.estimatedCredits + 2, 20), // Increase credits with more stops
-    }));
+    setState((prev) => {
+      const newStops = [...prev.stops, newStop];
+      // Automaticamente mostrar confirmação se tiver 2+ paradas
+      const shouldShowConfirmation = newStops.length >= 2 && prev.isTracing;
+
+      return {
+        ...prev,
+        stops: newStops,
+        estimatedCredits: Math.min(prev.estimatedCredits + 2, 20), // Increase credits with more stops
+        // Mostrar confirmação automaticamente quando tiver 2+ paradas
+        showConfirmDialog: shouldShowConfirmation ? true : prev.showConfirmDialog,
+      };
+    });
   };
 
   const removeLastStop = () => {
@@ -322,8 +330,14 @@ export const TraceRouteProvider: React.FC<TraceRouteProviderProps> = ({
       isRouteTraced: true,
       navigationMode: "traced",
       showTraceConfirmed: true, // Ativa o modo "Navegar/Desistir"
-      isTracing: false, // Sai do modo de traçamento
+      isTracing: false, // Sai do modo de tra��amento
     }));
+
+    // Dispatcha evento para que o mapa trace a rota automaticamente
+    window.dispatchEvent(new CustomEvent('traceRoute', {
+      detail: { stops: state.stops }
+    }));
+
     console.log("Tracing confirmed! Drawing route...");
   };
 
@@ -477,7 +491,14 @@ export const TraceRouteProvider: React.FC<TraceRouteProviderProps> = ({
 
       if (isRouteCompleted) {
         console.log("Todas as paradas foram concluídas! Abrindo resumo final.");
-        // Quando todas as paradas são concluídas, abrir modal de resumo final
+        // Quando todas as paradas são concluídas, abrir modal de resumo final após um pequeno delay
+        setTimeout(() => {
+          setState(current => ({
+            ...current,
+            showFinalSummaryModal: true
+          }));
+        }, 500);
+
         return {
           ...prev,
           stops: updatedStops,
@@ -488,7 +509,6 @@ export const TraceRouteProvider: React.FC<TraceRouteProviderProps> = ({
           },
           isInActiveNavigation: false,
           allStopsCompleted: true,
-          showFinalSummaryModal: true, // Abrir automaticamente o modal de resumo final
         };
       }
 

--- a/client/contexts/TraceRouteContext.tsx
+++ b/client/contexts/TraceRouteContext.tsx
@@ -266,7 +266,9 @@ export const TraceRouteProvider: React.FC<TraceRouteProviderProps> = ({
         stops: newStops,
         estimatedCredits: Math.min(prev.estimatedCredits + 2, 20), // Increase credits with more stops
         // Mostrar confirmação automaticamente quando tiver 2+ paradas
-        showConfirmDialog: shouldShowConfirmation ? true : prev.showConfirmDialog,
+        showConfirmDialog: shouldShowConfirmation
+          ? true
+          : prev.showConfirmDialog,
       };
     });
   };
@@ -334,9 +336,11 @@ export const TraceRouteProvider: React.FC<TraceRouteProviderProps> = ({
     }));
 
     // Dispatcha evento para que o mapa trace a rota automaticamente
-    window.dispatchEvent(new CustomEvent('traceRoute', {
-      detail: { stops: state.stops }
-    }));
+    window.dispatchEvent(
+      new CustomEvent("traceRoute", {
+        detail: { stops: state.stops },
+      }),
+    );
 
     console.log("Tracing confirmed! Drawing route...");
   };
@@ -493,9 +497,9 @@ export const TraceRouteProvider: React.FC<TraceRouteProviderProps> = ({
         console.log("Todas as paradas foram concluídas! Abrindo resumo final.");
         // Quando todas as paradas são concluídas, abrir modal de resumo final após um pequeno delay
         setTimeout(() => {
-          setState(current => ({
+          setState((current) => ({
             ...current,
-            showFinalSummaryModal: true
+            showFinalSummaryModal: true,
           }));
         }, 500);
 

--- a/client/layouts/mobile/MobileInternalLayout.tsx
+++ b/client/layouts/mobile/MobileInternalLayout.tsx
@@ -293,7 +293,12 @@ const MobileInternalLayout: React.FC = () => {
         break;
       case "finalize_planning":
         // PLANEJAMENTO: Finaliza planejamento e abre confirmação para traçar rota
-        showTraceConfirmation();
+        if (traceState.stops.length >= 2) {
+          showTraceConfirmation();
+        } else {
+          // Se não tem paradas suficientes, mostrar feedback
+          alert("Adicione pelo menos 2 paradas para traçar a rota");
+        }
         break;
       case "cancel":
         // PLANEJAMENTO: Cancela o planejamento e volta à exploração

--- a/client/layouts/mobile/MobileInternalLayout.tsx
+++ b/client/layouts/mobile/MobileInternalLayout.tsx
@@ -578,7 +578,13 @@ const MobileInternalLayout: React.FC = () => {
       <FinalSummaryModal
         isOpen={traceState.showFinalSummaryModal}
         onClose={closeFinalSummaryModal}
-        onSaveAndComplete={saveAndCompleteRoute}
+        onSaveAndComplete={() => {
+          try {
+            saveAndCompleteRoute();
+          } catch (error) {
+            console.error("Erro ao salvar rota:", error);
+          }
+        }}
       />
     </div>
   );

--- a/client/layouts/mobile/MobileInternalLayout.tsx
+++ b/client/layouts/mobile/MobileInternalLayout.tsx
@@ -152,7 +152,7 @@ const MobileInternalLayout: React.FC = () => {
     },
   ];
 
-  // 2a. PLANEJAMENTO INICIAL - Adicionando primeiras paradas
+  // 2. PLANEJAMENTO - Adicionando e configurando paradas
   const planningNavigationItems = [
     {
       name: "Adicionar",
@@ -168,30 +168,6 @@ const MobileInternalLayout: React.FC = () => {
       name: "Configurar",
       icon: Cog,
       action: "configure",
-    },
-    {
-      name: "Cancelar",
-      icon: X,
-      action: "cancel",
-    },
-  ];
-
-  // 2b. PLANEJAMENTO PRONTO - Com 2+ paradas, pronto para traçar
-  const planningReadyNavigationItems = [
-    {
-      name: "Adicionar",
-      icon: Plus,
-      action: "add",
-    },
-    {
-      name: "Limpar",
-      icon: Trash2,
-      action: "clear",
-    },
-    {
-      name: "Finalizar",
-      icon: Navigation,
-      action: "finalize_planning",
     },
     {
       name: "Cancelar",

--- a/client/layouts/mobile/MobileInternalLayout.tsx
+++ b/client/layouts/mobile/MobileInternalLayout.tsx
@@ -272,7 +272,7 @@ const MobileInternalLayout: React.FC = () => {
         if (traceState.stops.length >= 2) {
           showTraceConfirmation();
         } else {
-          // Se não tem paradas suficientes, mostrar feedback
+          // Se n��o tem paradas suficientes, mostrar feedback
           alert("Adicione pelo menos 2 paradas para traçar a rota");
         }
         break;
@@ -329,11 +329,7 @@ const MobileInternalLayout: React.FC = () => {
         return routeTracedNavigationItems;
       } else if (traceState.isTracing) {
         // 2. PLANEJAMENTO - Criando rota, adicionando paradas
-        if (traceState.stops.length >= 2) {
-          return planningReadyNavigationItems;
-        } else {
-          return planningNavigationItems;
-        }
+        return planningNavigationItems;
       } else {
         // 1. EXPLORAÇÃO - Estado inicial, explorando mapa
         return explorationNavigationItems;

--- a/client/layouts/mobile/MobileInternalLayout.tsx
+++ b/client/layouts/mobile/MobileInternalLayout.tsx
@@ -267,15 +267,6 @@ const MobileInternalLayout: React.FC = () => {
         // Abre configurações avançadas da rota
         openConfiguration();
         break;
-      case "finalize_planning":
-        // PLANEJAMENTO: Finaliza planejamento e abre confirmação para traçar rota
-        if (traceState.stops.length >= 2) {
-          showTraceConfirmation();
-        } else {
-          // Se n��o tem paradas suficientes, mostrar feedback
-          alert("Adicione pelo menos 2 paradas para traçar a rota");
-        }
-        break;
       case "cancel":
         // PLANEJAMENTO: Cancela o planejamento e volta à exploração
         cancelTrace();

--- a/client/pages/internal/MapPage.tsx
+++ b/client/pages/internal/MapPage.tsx
@@ -103,6 +103,7 @@ const MapPage: React.FC = () => {
   const stopMarkers = useRef<mapboxgl.Marker[]>([]);
   const lastCoordinatesRef = useRef<[number, number] | null>(null);
   const lastUpdateTimeRef = useRef<number>(0);
+  const [currentUserLocation, setCurrentUserLocation] = useState<[number, number] | null>(null);
 
   const {
     state: traceState,

--- a/client/pages/internal/MapPage.tsx
+++ b/client/pages/internal/MapPage.tsx
@@ -342,6 +342,10 @@ const MapPage: React.FC = () => {
               (position) => {
                 const { latitude, longitude } = position.coords;
 
+                // Armazenar localização atual do usuário
+                setCurrentUserLocation([longitude, latitude]);
+                console.log("Localização atual armazenada (auto-detect):", [longitude, latitude]);
+
                 if (map.current) {
                   // Smooth fly to user's actual location
                   map.current.flyTo({
@@ -1378,7 +1382,7 @@ const MapPage: React.FC = () => {
                   "Token do Mapbox não configurado. Configure VITE_MAPBOX_ACCESS_TOKEN para ativar o mapa."}
               </p>
               <div className="text-xs text-muted-foreground/70">
-                Esta é uma versão de demonstração da plataforma Viwe.
+                Esta �� uma versão de demonstração da plataforma Viwe.
               </div>
             </div>
           </div>

--- a/client/pages/internal/MapPage.tsx
+++ b/client/pages/internal/MapPage.tsx
@@ -552,6 +552,7 @@ const MapPage: React.FC = () => {
       if (!map.current || stops.length < 2) return;
 
       setIsTracingRoute(true);
+      console.log("Iniciando traçamento da rota com", stops.length, "paradas");
 
       const result = await handleAsyncError(async () => {
         // Convert stops to coordinates string for Mapbox Directions API

--- a/client/pages/internal/MapPage.tsx
+++ b/client/pages/internal/MapPage.tsx
@@ -1411,6 +1411,13 @@ const MapPage: React.FC = () => {
           <Target className="h-5 w-5 text-gray-600" />
         </button>
 
+        {/* Route Tracer Feedback */}
+        <ViweRouteTracer
+          isVisible={isTracingRoute || (traceState.isRouteTraced && !traceState.isInActiveNavigation)}
+          stopsCount={traceState.stops.length}
+          isTracing={isTracingRoute}
+        />
+
         {/* REMOVIDO: Todos os controles de rota agora são controlados pelo navbar */}
 
         {/* Navigation Modals */}

--- a/client/pages/internal/MapPage.tsx
+++ b/client/pages/internal/MapPage.tsx
@@ -35,6 +35,7 @@ import ModalHeader from "../../components/shared/ModalHeader";
 import NavigationDetailsModal from "../../components/shared/NavigationDetailsModal";
 import NavigationAdjustmentsModal from "../../components/shared/NavigationAdjustmentsModal";
 import FinalSummaryModal from "../../components/shared/FinalSummaryModal";
+import ViweRouteTracer from "../../components/shared/ViweRouteTracer";
 import { useRouteModal } from "../../hooks/use-route-modal";
 import { useTraceRoute } from "../../contexts/TraceRouteContext";
 import ViweLoader from "../../components/shared/ViweLoader";

--- a/client/pages/internal/MapPage.tsx
+++ b/client/pages/internal/MapPage.tsx
@@ -1076,6 +1076,7 @@ const MapPage: React.FC = () => {
   useEffect(() => {
     const handleTraceRoute = async (event: any) => {
       const { stops } = event.detail;
+      console.log("Evento traceRoute recebido, traçando rota automaticamente...");
       await traceRouteOnMap(stops);
     };
 
@@ -1085,6 +1086,7 @@ const MapPage: React.FC = () => {
         map.current.removeLayer("route");
         map.current.removeSource("route");
       }
+      console.log("Rota limpa do mapa");
     };
 
     window.addEventListener("traceRoute", handleTraceRoute);
@@ -1095,6 +1097,18 @@ const MapPage: React.FC = () => {
       window.removeEventListener("clearRoute", handleClearRoute);
     };
   }, [traceRouteOnMap]);
+
+  // Auto-trace route when it becomes traced in context
+  useEffect(() => {
+    if (traceState.isRouteTraced && traceState.stops.length >= 2) {
+      // Garantir que a rota seja traçada no mapa quando confirmada
+      const timeoutId = setTimeout(() => {
+        traceRouteOnMap(traceState.stops);
+      }, 100);
+
+      return () => clearTimeout(timeoutId);
+    }
+  }, [traceState.isRouteTraced, traceState.stops, traceRouteOnMap]);
 
   // Cleanup all resources on unmount
   useEffect(() => {

--- a/client/pages/internal/MapPage.tsx
+++ b/client/pages/internal/MapPage.tsx
@@ -1148,8 +1148,9 @@ const MapPage: React.FC = () => {
 
   // Auto-trace route when it becomes traced in context
   useEffect(() => {
-    if (traceState.isRouteTraced && traceState.stops.length >= 2) {
+    if (traceState.isRouteTraced && traceState.stops.length >= 1) {
       // Garantir que a rota seja traçada no mapa quando confirmada
+      // Agora traça desde a localização atual até as paradas
       const timeoutId = setTimeout(() => {
         traceRouteOnMap(traceState.stops);
       }, 100);

--- a/client/pages/internal/MapPage.tsx
+++ b/client/pages/internal/MapPage.tsx
@@ -103,7 +103,9 @@ const MapPage: React.FC = () => {
   const stopMarkers = useRef<mapboxgl.Marker[]>([]);
   const lastCoordinatesRef = useRef<[number, number] | null>(null);
   const lastUpdateTimeRef = useRef<number>(0);
-  const [currentUserLocation, setCurrentUserLocation] = useState<[number, number] | null>(null);
+  const [currentUserLocation, setCurrentUserLocation] = useState<
+    [number, number] | null
+  >(null);
 
   const {
     state: traceState,
@@ -344,7 +346,10 @@ const MapPage: React.FC = () => {
 
                 // Armazenar localização atual do usuário
                 setCurrentUserLocation([longitude, latitude]);
-                console.log("Localização atual armazenada (auto-detect):", [longitude, latitude]);
+                console.log("Localização atual armazenada (auto-detect):", [
+                  longitude,
+                  latitude,
+                ]);
 
                 if (map.current) {
                   // Smooth fly to user's actual location
@@ -567,22 +572,29 @@ const MapPage: React.FC = () => {
         // Se não temos localização atual, tentar obter
         if (!startingPoint) {
           try {
-            const position = await new Promise<GeolocationPosition>((resolve, reject) => {
-              if (!navigator.geolocation) {
-                reject(new Error('Geolocalização não suportada'));
-                return;
-              }
-              navigator.geolocation.getCurrentPosition(resolve, reject, {
-                enableHighAccuracy: true,
-                timeout: 5000,
-                maximumAge: 60000, // 1 minuto de cache
-              });
-            });
-            startingPoint = [position.coords.longitude, position.coords.latitude];
+            const position = await new Promise<GeolocationPosition>(
+              (resolve, reject) => {
+                if (!navigator.geolocation) {
+                  reject(new Error("Geolocalização não suportada"));
+                  return;
+                }
+                navigator.geolocation.getCurrentPosition(resolve, reject, {
+                  enableHighAccuracy: true,
+                  timeout: 5000,
+                  maximumAge: 60000, // 1 minuto de cache
+                });
+              },
+            );
+            startingPoint = [
+              position.coords.longitude,
+              position.coords.latitude,
+            ];
             setCurrentUserLocation(startingPoint);
             console.log("Localização atual obtida:", startingPoint);
           } catch (error) {
-            console.warn("Não foi possível obter localização atual, usando centro do mapa");
+            console.warn(
+              "Não foi possível obter localização atual, usando centro do mapa",
+            );
             // Fallback para centro atual do mapa
             const center = map.current?.getCenter();
             if (center) {
@@ -595,14 +607,23 @@ const MapPage: React.FC = () => {
         }
 
         // Criar array de coordenadas: localização atual + paradas
-        const allCoordinates = [startingPoint, ...stops.map(stop => stop.coordinates)];
+        const allCoordinates = [
+          startingPoint,
+          ...stops.map((stop) => stop.coordinates),
+        ];
 
         // Convert coordinates to string for Mapbox Directions API
         const coordinates = allCoordinates
           .map((coord) => `${coord[0]},${coord[1]}`)
           .join(";");
 
-        console.log("Traçando rota de", startingPoint, "para", stops.length, "paradas");
+        console.log(
+          "Traçando rota de",
+          startingPoint,
+          "para",
+          stops.length,
+          "paradas",
+        );
 
         // Call Mapbox Directions API using centralized config
         const apiUrl = createMapboxApiUrl(
@@ -785,7 +806,10 @@ const MapPage: React.FC = () => {
 
         // Armazenar localização atual do usuário
         setCurrentUserLocation([longitude, latitude]);
-        console.log("Localização atual armazenada (find my location):", [longitude, latitude]);
+        console.log("Localização atual armazenada (find my location):", [
+          longitude,
+          latitude,
+        ]);
 
         if (map.current) {
           // Voa para a localização atual do usuário
@@ -1124,7 +1148,9 @@ const MapPage: React.FC = () => {
   useEffect(() => {
     const handleTraceRoute = async (event: any) => {
       const { stops } = event.detail;
-      console.log("Evento traceRoute recebido, traçando rota automaticamente...");
+      console.log(
+        "Evento traceRoute recebido, traçando rota automaticamente...",
+      );
       await traceRouteOnMap(stops);
     };
 
@@ -1461,7 +1487,10 @@ const MapPage: React.FC = () => {
 
         {/* Route Tracer Feedback */}
         <ViweRouteTracer
-          isVisible={isTracingRoute || (traceState.isRouteTraced && !traceState.isInActiveNavigation)}
+          isVisible={
+            isTracingRoute ||
+            (traceState.isRouteTraced && !traceState.isInActiveNavigation)
+          }
           stopsCount={traceState.stops.length}
           isTracing={isTracingRoute}
         />

--- a/client/pages/internal/MapPage.tsx
+++ b/client/pages/internal/MapPage.tsx
@@ -783,6 +783,10 @@ const MapPage: React.FC = () => {
       (position) => {
         const { latitude, longitude } = position.coords;
 
+        // Armazenar localização atual do usuário
+        setCurrentUserLocation([longitude, latitude]);
+        console.log("Localização atual armazenada (find my location):", [longitude, latitude]);
+
         if (map.current) {
           // Voa para a localização atual do usuário
           map.current.flyTo({


### PR DESCRIPTION
## Purpose

The user requested a fix for step 6 of the flow where the route should be traced from the user's real location to the stops, rather than just between stops.

## Code changes

- **Route tracing logic**: Modified `traceRouteOnMap()` to start routes from user's current location instead of just connecting stops
- **User location tracking**: Added `currentUserLocation` state to store and reuse user's GPS coordinates
- **Geolocation integration**: Enhanced location detection with fallback strategies (map center → São Paulo default)
- **UI improvements**: 
  - Added `ViweRouteTracer` component for visual feedback during route tracing
  - Updated button text to "Finalizar Planejamento" when ready to trace
  - Simplified navigation items by removing redundant "Finalizar" button
- **Auto-confirmation**: Routes with 2+ stops now automatically show confirmation dialog
- **Event handling**: Added automatic route tracing when route is confirmed via custom events
- **Validation**: Updated form validation to require only 1 stop minimum for map page context

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 20`

🔗 [Edit in Builder.io](https://builder.io/app/projects/9457dafbaade4862ac410be7f7c2f2c4/swoosh-world)

👀 [Preview Link](https://9457dafbaade4862ac410be7f7c2f2c4-swoosh-world.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>9457dafbaade4862ac410be7f7c2f2c4</projectId>-->
<!--<branchName>swoosh-world</branchName>-->